### PR TITLE
datetime and datetime-local input displays error

### DIFF
--- a/knockout-date-bindings.js
+++ b/knockout-date-bindings.js
@@ -29,7 +29,7 @@
             dateFormat = 'YYYY-MM-DD';
         }
         else if (type == 'datetime-local' || type == 'datetime') {
-            dateFormat = 'YYYY-MM-DDThh:mm';
+            dateFormat = 'YYYY-MM-DDTHH:mm';
         }
         else if (type == 'month') {
             dateFormat = 'YYYY-MM';


### PR DESCRIPTION
an html 5 datetime and datetime-local input would always show am on the value.  Use the `HH` rather than `hh` to force a 24 hour clock output.